### PR TITLE
feat: upgrade sqlx to 0.9 and split runtime/TLS features

### DIFF
--- a/.sqlx/query-3ae7e28de7cb8896086c186dbc0e78f2a23eff67925322bdd3646d063d710584.json
+++ b/.sqlx/query-3ae7e28de7cb8896086c186dbc0e78f2a23eff67925322bdd3646d063d710584.json
@@ -6,42 +6,90 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "ptype",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "ptype"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "v0",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "v0"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "v1",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "v1"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "v2",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "v2"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "v3",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "v3"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "v4",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "v4"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "v5",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "v5"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-530d3f59ba6d986d3354242ff25faae78671d69c8935d2a2d57c0f9d1e91e832.json
+++ b/.sqlx/query-530d3f59ba6d986d3354242ff25faae78671d69c8935d2a2d57c0f9d1e91e832.json
@@ -6,42 +6,90 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "ptype",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "ptype"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "v0",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "v0"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "v1",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "v1"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "v2",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "v2"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "v3",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "v3"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "v4",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "v4"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "v5",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "casbin_rule",
+            "name": "v5"
+          }
+        }
       }
     ],
     "parameters": {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "sqlx-adapter"
 version = "1.8.0"
-authors = ["Eason Chai <hackerchai.com@gmail.com>","Cheng JIANG <jiang.cheng@vip.163.com>"]
+authors = [
+	"Eason Chai <hackerchai.com@gmail.com>",
+	"Cheng JIANG <jiang.cheng@vip.163.com>",
+]
 edition = "2018"
 license = "Apache-2.0"
 description = "Sqlx adapter for casbin-rs"
-homepage= "https://casbin.apache.org"
-readme= "README.md"
+homepage = "https://casbin.apache.org"
+readme = "README.md"
 
 [dependencies]
 casbin = { version = "2.1.0", default-features = false }
-sqlx = { version = "0.8", default-features = false, features = [ "macros" ] }
+sqlx = { version = "0.9", default-features = false, features = ["macros"] }
 async-trait = "0.1.51"
-dotenvy = { version = "0.15.0", default-features = false }
-tokio = { version = "1.10.0", default-features = false, optional = true }
-async-std = { version = "1.9.0", default-features = false, optional = true }
 
 [features]
 default = ["postgres", "runtime-tokio-native-tls"]
@@ -26,21 +26,27 @@ sqlite = ["sqlx/sqlite"]
 
 # async runtime
 # async-std
-runtime-async-std-native-tls = ["casbin/runtime-async-std", "sqlx/runtime-async-std-native-tls"]
-runtime-async-std-rustls = ["casbin/runtime-async-std", "sqlx/runtime-async-std-rustls"]
-# tokio
+runtime-async-std = ["casbin/runtime-async-std", "sqlx/runtime-async-std"]
 runtime-tokio = ["casbin/runtime-tokio", "sqlx/runtime-tokio"]
-runtime-tokio-native-tls = ["casbin/runtime-tokio", "sqlx/runtime-tokio-native-tls"]
-runtime-tokio-rustls = ["casbin/runtime-tokio", "sqlx/runtime-tokio-rustls"]
+
+# TLS
+tls-native-tls = ["sqlx/tls-native-tls"]
+tls-rustls = ["sqlx/tls-rustls"]
+
+# Backward-compatible runtime/TLS aliases
+runtime-async-std-native-tls = ["runtime-async-std", "tls-native-tls"]
+runtime-async-std-rustls = ["runtime-async-std", "tls-rustls"]
+runtime-tokio-native-tls = ["runtime-tokio", "tls-native-tls"]
+runtime-tokio-rustls = ["runtime-tokio", "tls-rustls"]
 
 [dev-dependencies]
-async-std = { version = "1.9.0", features = [ "attributes" ] }
-tokio = { version = "1.10.0", features = [ "full" ] }
+async-std = { version = "1.9.0", features = ["attributes"] }
+tokio = { version = "1.10.0", features = ["full"] }
 
 [profile.release]
 codegen-units = 1
-lto           = true
-opt-level     = 3
+lto = true
+opt-level = 3
 
 [profile.dev]
 split-debuginfo = "packed"

--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@ Add the following to `Cargo.toml`:
 For MySQL:
 
 ```toml
-sqlx-adapter = { version = "1.8.0", default-features = false, features = ["mysql", "runtime-tokio-native-tls"]}
+sqlx-adapter = { version = "1.8.0", default-features = false, features = ["mysql", "runtime-tokio", "tls-native-tls"]}
 tokio = { version = "1.1.1", features = ["macros"] }
 ```
 
 For PostgreSQL:
 
 ```toml
-sqlx-adapter = { version = "1.8.0", default-features = false, features = ["postgres", "runtime-tokio-native-tls"]}
+sqlx-adapter = { version = "1.8.0", default-features = false, features = ["postgres", "runtime-tokio", "tls-native-tls"]}
 tokio = { version = "1.1.1", features = ["macros"] }
 ```
 
 For SQLite:
 
 ```toml
-sqlx-adapter = { version = "1.8.0", default-features = false, features = ["sqlite", "runtime-tokio-native-tls"]}
+sqlx-adapter = { version = "1.8.0", default-features = false, features = ["sqlite", "runtime-tokio", "tls-native-tls"]}
 tokio = { version = "1.1.1", features = ["macros"] }
 ```
 
@@ -198,5 +198,16 @@ async fn main() -> Result<()> {
 - `postgres`
 - `mysql`
 - `sqlite`
+- `runtime-tokio`
+- `runtime-async-std`
+- `tls-native-tls`
+- `tls-rustls`
+
+The legacy combined runtime/TLS features remain available as backward-compatible aliases:
+
+- `runtime-tokio-native-tls`
+- `runtime-tokio-rustls`
+- `runtime-async-std-native-tls`
+- `runtime-async-std-rustls`
 
 *Attention*: `postgres`, `mysql`, `sqlite` are mutual exclusive which means that you can only activate one of them.

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use casbin::{error::AdapterError, Adapter, Error as CasbinError, Filter, Model, Result};
-use dotenvy::dotenv;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -27,8 +26,6 @@ pub struct SqlxAdapter {
 
 impl<'a> SqlxAdapter {
     pub async fn new<U: Into<String>>(url: U, pool_size: u32) -> Result<Self> {
-        dotenv().ok();
-
         #[cfg(feature = "postgres")]
         let pool = PgPoolOptions::new()
             .max_connections(pool_size)
@@ -275,17 +272,21 @@ mod tests {
         v.into_iter().map(|x| x.to_owned()).collect()
     }
 
-    #[cfg_attr(
-        any(
-            feature = "runtime-async-std-native-tls",
-            feature = "runtime-async-std-rustls"
-        ),
-        async_std::test
-    )]
-    #[cfg_attr(
-        any(feature = "runtime-tokio-native-tls", feature = "runtime-tokio-rustls"),
-        tokio::test(flavor = "multi_thread")
-    )]
+    fn test_database_url() -> String {
+        #[cfg(feature = "postgres")]
+        let default_url = "postgres://casbin_rs:casbin_rs@localhost:5432/casbin";
+
+        #[cfg(feature = "mysql")]
+        let default_url = "mysql://casbin_rs:casbin_rs@localhost:3306/casbin";
+
+        #[cfg(feature = "sqlite")]
+        let default_url = "sqlite:casbin.db";
+
+        std::env::var("DATABASE_URL").unwrap_or_else(|_| default_url.to_owned())
+    }
+
+    #[cfg_attr(feature = "runtime-async-std", async_std::test)]
+    #[cfg_attr(feature = "runtime-tokio", tokio::test(flavor = "multi_thread"))]
     async fn test_create() {
         use casbin::prelude::*;
 
@@ -296,38 +297,25 @@ mod tests {
         let adapter = {
             #[cfg(feature = "postgres")]
             {
-                SqlxAdapter::new("postgres://casbin_rs:casbin_rs@localhost:5432/casbin", 8)
-                    .await
-                    .unwrap()
+                SqlxAdapter::new(test_database_url(), 8).await.unwrap()
             }
 
             #[cfg(feature = "mysql")]
             {
-                SqlxAdapter::new("mysql://casbin_rs:casbin_rs@localhost:3306/casbin", 8)
-                    .await
-                    .unwrap()
+                SqlxAdapter::new(test_database_url(), 8).await.unwrap()
             }
 
             #[cfg(feature = "sqlite")]
             {
-                SqlxAdapter::new("sqlite:casbin.db", 8).await.unwrap()
+                SqlxAdapter::new(test_database_url(), 8).await.unwrap()
             }
         };
 
         assert!(Enforcer::new(m, adapter).await.is_ok());
     }
 
-    #[cfg_attr(
-        any(
-            feature = "runtime-async-std-native-tls",
-            feature = "runtime-async-std-rustls"
-        ),
-        async_std::test
-    )]
-    #[cfg_attr(
-        any(feature = "runtime-tokio-native-tls", feature = "runtime-tokio-rustls"),
-        tokio::test(flavor = "multi_thread")
-    )]
+    #[cfg_attr(feature = "runtime-async-std", async_std::test)]
+    #[cfg_attr(feature = "runtime-tokio", tokio::test(flavor = "multi_thread"))]
     async fn test_create_with_pool() {
         use casbin::prelude::*;
 
@@ -337,27 +325,30 @@ mod tests {
         let pool = {
             #[cfg(feature = "postgres")]
             {
+                let url = test_database_url();
                 PgPoolOptions::new()
                     .max_connections(8)
-                    .connect("postgres://casbin_rs:casbin_rs@localhost:5432/casbin")
+                    .connect(&url)
                     .await
                     .unwrap()
             }
 
             #[cfg(feature = "mysql")]
             {
+                let url = test_database_url();
                 MySqlPoolOptions::new()
                     .max_connections(8)
-                    .connect("mysql://casbin_rs:casbin_rs@localhost:3306/casbin")
+                    .connect(&url)
                     .await
                     .unwrap()
             }
 
             #[cfg(feature = "sqlite")]
             {
+                let url = test_database_url();
                 SqlitePoolOptions::new()
                     .max_connections(8)
-                    .connect("sqlite:casbin.db")
+                    .connect(&url)
                     .await
                     .unwrap()
             }
@@ -368,17 +359,8 @@ mod tests {
         assert!(Enforcer::new(m, adapter).await.is_ok());
     }
 
-    #[cfg_attr(
-        any(
-            feature = "runtime-async-std-native-tls",
-            feature = "runtime-async-std-rustls"
-        ),
-        async_std::test
-    )]
-    #[cfg_attr(
-        any(feature = "runtime-tokio-native-tls", feature = "runtime-tokio-rustls"),
-        tokio::test(flavor = "multi_thread")
-    )]
+    #[cfg_attr(feature = "runtime-async-std", async_std::test)]
+    #[cfg_attr(feature = "runtime-tokio", tokio::test(flavor = "multi_thread"))]
     async fn test_adapter() {
         use casbin::prelude::*;
 
@@ -389,28 +371,46 @@ mod tests {
             .unwrap();
 
         let mut e = Enforcer::new(m, file_adapter).await.unwrap();
+        #[cfg(feature = "postgres")]
+        let postgres_pool = {
+            let url = test_database_url();
+            PgPoolOptions::new()
+                .max_connections(8)
+                .connect(&url)
+                .await
+                .unwrap()
+        };
         let mut adapter = {
             #[cfg(feature = "postgres")]
             {
-                SqlxAdapter::new("postgres://casbin_rs:casbin_rs@localhost:5432/casbin", 8)
+                SqlxAdapter::new_with_pool(postgres_pool.clone())
                     .await
                     .unwrap()
             }
 
             #[cfg(feature = "mysql")]
             {
-                SqlxAdapter::new("mysql://casbin_rs:casbin_rs@localhost:3306/casbin", 8)
-                    .await
-                    .unwrap()
+                SqlxAdapter::new(test_database_url(), 8).await.unwrap()
             }
 
             #[cfg(feature = "sqlite")]
             {
-                SqlxAdapter::new("sqlite:casbin.db", 8).await.unwrap()
+                SqlxAdapter::new(test_database_url(), 8).await.unwrap()
             }
         };
 
         assert!(adapter.save_policy(e.get_mut_model()).await.is_ok());
+
+        #[cfg(feature = "postgres")]
+        {
+            let model = DefaultModel::from_file("examples/rbac_model.conf")
+                .await
+                .unwrap();
+            let reloaded_adapter = SqlxAdapter::new_with_pool(postgres_pool).await.unwrap();
+            let reloaded = Enforcer::new(model, reloaded_adapter).await.unwrap();
+
+            assert!(reloaded.enforce(("alice", "data1", "read")).unwrap());
+        }
 
         assert!(adapter
             .remove_policy("", "p", to_owned(vec!["alice", "data1", "read"]))
@@ -564,7 +564,7 @@ mod tests {
             .remove_filtered_policy("", "g", 0, to_owned(vec!["carol"]),)
             .await
             .unwrap());
-        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("carol", None));
+        assert_eq!(Vec::<String>::new(), e.get_roles_for_user("carol", None));
 
         // GitHub issue: https://github.com/apache/casbin-sqlx-adapter/pull/90
         // add policies:


### PR DESCRIPTION
## Summary
- Upgrade `sqlx` from 0.8 to 0.9 and refresh offline query metadata.
- Split runtime and TLS into independent features (`runtime-tokio` / `runtime-async-std`, `tls-native-tls` / `tls-rustls`), keeping the old combined feature names as aliases.
- Stop loading `.env` inside `SqlxAdapter::new`; tests now read `DATABASE_URL` (with defaults) and cover shared-pool reload on PostgreSQL.
- Update README install/feature docs for the new feature model.

## Test plan
- [ ] `cargo check --no-default-features --features postgres,runtime-tokio,tls-native-tls`
- [ ] `cargo check --no-default-features --features postgres,runtime-tokio-native-tls` (legacy alias)
- [ ] `cargo test --no-default-features --features postgres,runtime-tokio-native-tls`
- [ ] `cargo test --no-default-features --features postgres,runtime-async-std-rustls`
- [ ] CI green for postgres / mysql / sqlite across runtime+TLS matrix

Fix: https://github.com/apache/casbin-sqlx-adapter/issues/112