### PR TITLE
docs: add DISCLAIMER and NOTICE

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,0 +1,5 @@
+Apache Casbin (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+
+Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
+
+While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+Apache Casbin (Incubating)
+Copyright 2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+Portions of this software were originally developed by the Casbin project.
+Copyright 2020-2026 The casbin Authors.


### PR DESCRIPTION
As an Apache (Incubating) project, the repository root is missing the two files required by the Apache Incubator:

- DISCLAIMER: states that the project is undergoing incubation at the ASF and has not yet been fully endorsed by the ASF
- NOTICE: declares copyright ownership as required by the ASF, covering both The Apache Software Foundation copyright and the original Casbin project copyright

Verified on 2026-08-06 that neither file exists in upstream, fork, or local (all at 8134e41), and that Apache Casbin is still incubating (entered incubation 2026-02-07, not graduated). Only 4 of 239 apache/casbin-* repos have these files so far (casbin, jcasbin, jcasbin-jdbc-adapter, pycasbin).

What changed:

- Add DISCLAIMER (5 lines) - standard ASF incubation disclaimer, byte-identical to casbin / casbin-pycasbin / casbin-jcasbin-jdbc-adapter
- Add NOTICE (8 lines) - Copyright 2020-2026 The casbin Authors. (2020 matches this repo's first commit on 2020-02-10)

Verification:

- DISCLAIMER blob identical to casbin-pycasbin (552 bytes)
- NOTICE contains "Apache Casbin (Incubating)" / "Copyright 2026 The Apache Software Foundation" / "Copyright 2020-2026 The casbin Authors."
- Commit ef9df66 contains only NOTICE + DISCLAIMER (13 insertions), working tree clean